### PR TITLE
Added support for multiple instances of Swiftmailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,32 @@ $repo = $this->getDoctrine()->getRepository("TweedeGolfSwiftmailerLoggerBundle:L
 
 ```
 
+### Use multiple or custom instances of Swift mailer
+If you are using multiple Swift instances on your application or if you have overwritten the name of your Swift instance, modify your `app/config.yml` as shown below:
+```
+tweede_golf_swiftmailer_logger:
+   swift_instances:
+        - default
+        - secondary_smtp
+        
+    loggers:
+        entity_logger:
+            enabled: true
+            
+# Swiftmailer Configuration as example
+#swiftmailer:
+#    default_mailer: default
+#    mailers:
+#        default:
+#            transport:  %swift_transport%
+#            username: %swift_username%
+#            password: %swift_password%
+#
+#        secondary_smtp:
+#            transport:  %swift_transport2%
+#            username: %swift_username2%
+#            password: %swift_password2%
+
+```
+
 [composer]: https://getcomposer.org/

--- a/src/TweedeGolf/SwiftmailerLoggerBundle/DependencyInjection/Configuration.php
+++ b/src/TweedeGolf/SwiftmailerLoggerBundle/DependencyInjection/Configuration.php
@@ -22,13 +22,16 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-            ->arrayNode('loggers')
-            ->children()
-            ->arrayNode('entity_logger')
-            ->children()
-            ->booleanNode('enabled')->defaultTrue()
+                ->arrayNode('swift_instances')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->arrayNode('loggers')
+                ->children()
+                    ->arrayNode('entity_logger')
+                    ->children()
+                        ->booleanNode('enabled')->defaultTrue()
         ;
-
+        
         return $treeBuilder;
     }
 }

--- a/src/TweedeGolf/SwiftmailerLoggerBundle/DependencyInjection/RegisterSendListenerCompilerPass.php
+++ b/src/TweedeGolf/SwiftmailerLoggerBundle/DependencyInjection/RegisterSendListenerCompilerPass.php
@@ -17,11 +17,23 @@ class RegisterSendListenerCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition('swiftmailer.mailer.default')) {
+        // bind listener to mailer instances
+        if($container->hasParameter('tweedegolf_swiftmailer_logger.swift_instances')){ // if instances are explicitly declared
+            
+            $instances = $container->getParameter('tweedegolf_swiftmailer_logger.swift_instances');
+            foreach($instances as $instance){
+                if($container->hasDefinition('swiftmailer.mailer.' . $instance)){
+                    $def = $container->getDefinition('swiftmailer.mailer.' . $instance);
+                    $def->addMethodCall('registerPlugin', array(new Reference('tweedegolf_swiftmailer_logger.send_listener')));
+                    unset($def);
+                }
+            }
+            
+        }else if ($container->hasDefinition('swiftmailer.mailer.default')) { // default instance only
+
             $def = $container->getDefinition('swiftmailer.mailer.default');
             $def->addMethodCall('registerPlugin', array(new Reference('tweedegolf_swiftmailer_logger.send_listener')));
             unset($def);
         }
     }
-
 }

--- a/src/TweedeGolf/SwiftmailerLoggerBundle/DependencyInjection/TweedeGolfSwiftmailerLoggerExtension.php
+++ b/src/TweedeGolf/SwiftmailerLoggerBundle/DependencyInjection/TweedeGolfSwiftmailerLoggerExtension.php
@@ -36,5 +36,10 @@ class TweedeGolfSwiftmailerLoggerExtension extends Extension
 
             unset($def);
         }
+        
+        // store the name of the swift instances we want to watch
+        if($config[ 'swift_instances' ]){
+            $container->setParameter( 'tweedegolf_swiftmailer_logger.swift_instances', $config[ 'swift_instances' ]);
+        }
     }
 }


### PR DESCRIPTION
Hi,
This pull request adds support for multiple instances of Swiftmailer.
It's usefull if you have different configuration defined (different smtp for example).
This doesn't break BC, the new parameters in app/config.yml are optional, the bundle will work the same way if they are omitted.

See updated README.md for usage.